### PR TITLE
Fix catalog-service workflow configuration

### DIFF
--- a/.github/workflows/catalog-service.yml
+++ b/.github/workflows/catalog-service.yml
@@ -12,7 +12,10 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     env:
-      working-directory: ${{ env.working-directory }}
+      working-directory: ./catalog-service
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Updated catalog-service.yml workflow with proper working directory configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures the GitHub Actions workflow to run all steps in the `catalog-service` directory via `env` and `defaults.run`.
> 
> - **CI/CD (GitHub Actions)**:
>   - Set `env.working-directory` to `./catalog-service` in `.github/workflows/catalog-service.yml`.
>   - Add `defaults.run.working-directory: ${{ env.working-directory }}` so all steps execute from the service directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291d8beda004f1491505628bc2b159511aef240f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->